### PR TITLE
Allow Players Ignoring Claims to Manage Permissions

### DIFF
--- a/src/main/java/net/kaikk/mc/gpp/Claim.java
+++ b/src/main/java/net/kaikk/mc/gpp/Claim.java
@@ -453,6 +453,12 @@ public class Claim {
 		if (this.hasExplicitPermission(player, ClaimPermission.MANAGE)) {
 			return null;
 		}
+		
+	      // players ignoring claims can do this
+        if (GriefPreventionPlus.getInstance().getDataStore().getPlayerData(player.getUniqueId()).ignoreClaims) {
+            return null;
+        }
+
 
 		// permission inheritance for subdivisions
 		if (this.getParent() != null) {


### PR DESCRIPTION
- Fix bug where players using /ignoreclaims could not manage permissions, and would instead recieve an error message telling them to use /ignoreclaims