### PR TITLE
A few tweaks

### DIFF
--- a/src/main/java/net/kaikk/mc/gpp/GriefPreventionPlus.java
+++ b/src/main/java/net/kaikk/mc/gpp/GriefPreventionPlus.java
@@ -502,7 +502,7 @@ public class GriefPreventionPlus extends JavaPlugin {
 	}
 	// determines whether creative anti-grief rules apply at a location
 	boolean creativeRulesApply(World world) {
-		return this.creativeRulesApply(world.getName());
+		return world != null && this.creativeRulesApply(world.getName());
 	}	
 
 	public boolean creativeRulesApply(String world) {

--- a/src/main/java/net/kaikk/mc/gpp/Utils.java
+++ b/src/main/java/net/kaikk/mc/gpp/Utils.java
@@ -7,13 +7,14 @@ public class Utils {
 	private Utils() {}
 	
 	public static boolean isFakePlayer(Player player) {
-		if (player.getName().charAt(0) != '[') {
+		/*if (player.getName().charAt(0) != '[') {
 			for (Player p : Bukkit.getOnlinePlayers()) {
 				if (player==p) {
 					return false;
 				}
 			}
 		}
-		return true;
+		return true;*/
+		return false;
 	}
 }

--- a/src/main/java/net/kaikk/mc/gpp/Utils.java
+++ b/src/main/java/net/kaikk/mc/gpp/Utils.java
@@ -7,14 +7,9 @@ public class Utils {
 	private Utils() {}
 	
 	public static boolean isFakePlayer(Player player) {
-		/*if (player.getName().charAt(0) != '[') {
-			for (Player p : Bukkit.getOnlinePlayers()) {
-				if (player==p) {
-					return false;
-				}
-			}
+		if (player.hasPlayedBefore()) {
+			return false;
 		}
-		return true;*/
-		return false;
+		return true;
 	}
 }

--- a/src/main/java/net/kaikk/mc/gpp/WorldGuardWrapper.java
+++ b/src/main/java/net/kaikk/mc/gpp/WorldGuardWrapper.java
@@ -1,9 +1,9 @@
 package net.kaikk.mc.gpp;
 
+import com.sk89q.worldedit.BlockVector;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
-import com.sk89q.worldedit.BlockVector;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.bukkit.permission.RegionPermissionModel;


### PR DESCRIPTION
* **Take only players who haven't played in the server as Fake Players:** some plugins use OfflinePlayers to check for permissions and fire events using them. At the moment, GPP only checks if the player is online, ignoring all other checks. With this change, only real Fake Players (who obviously haven't played in the server) are treated as one.
* **Fix NPE on /abandonallclaims**: fixes [this NPE](https://gist.github.com/Eufranio/8d4e73b4853f3a514cf009100256cc46), that happens when the world of an claim doesn't exist anymore (deleted, unloaded, etc).